### PR TITLE
fix: do not redraw when in input mode

### DIFF
--- a/plugin/numbertoggle.lua
+++ b/plugin/numbertoggle.lua
@@ -16,7 +16,11 @@ vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter", "CmdlineEn
    callback = function()
       if vim.o.nu then
          vim.opt.relativenumber = false
-         vim.cmd "redraw"
+         -- Conditional taken from https://github.com/rockyzhang24/dotfiles/commit/03dd14b5d43f812661b88c4660c03d714132abcf
+         -- Workaround for https://github.com/neovim/neovim/issues/32068
+         if not vim.tbl_contains({"@", "-"}, vim.v.event.cmdtype) then
+            vim.cmd "redraw"
+         end
       end
    end,
 })


### PR DESCRIPTION
Due to a [Neovim bug](https://github.com/neovim/neovim/issues/32068), when Neovim asks for input, (LSP code actions, spelling suggestions, etc.) the options are cleared leaving only the prompt. I used [this solution](https://github.com/rockyzhang24/dotfiles/commit/03dd14b5d43f812661b88c4660c03d714132abcf) to only redraw the screen when Neovim is not prompting for input.

Closes #26.