### PR TITLE
feat: allow disabling the plugin dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Use your favorite package manager. Example config with [packer.nvim](https://git
 use { "sitiom/nvim-numbertoggle" }
 ```
 
+## Disabling
+
+This plugin can be disabled in two ways:
+
+- Globally: set `vim.g.numbertoggle_disable` to `true`.
+- Locally for a buffer: set `vim.b.numbertoggle_disable` to `true`.
+
 ## Acknowledgment
 
 https://github.com/jeffkreeftmeijer/vim-numbertoggle

--- a/plugin/numbertoggle.lua
+++ b/plugin/numbertoggle.lua
@@ -1,9 +1,16 @@
 local augroup = vim.api.nvim_create_augroup("numbertoggle", {})
 
+local function is_disabled()
+   return vim.g.numbertoggle_disable or vim.b.numbertoggle_disable
+end
+
 vim.api.nvim_create_autocmd({ "BufEnter", "FocusGained", "InsertLeave", "CmdlineLeave", "WinEnter" }, {
    pattern = "*",
    group = augroup,
    callback = function()
+      if is_disabled() then
+         return
+      end
       if vim.o.nu and vim.api.nvim_get_mode().mode ~= "i" then
          vim.opt.relativenumber = true
       end
@@ -14,6 +21,9 @@ vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter", "CmdlineEn
    pattern = "*",
    group = augroup,
    callback = function()
+      if is_disabled() then
+         return
+      end
       if vim.o.nu then
          vim.opt.relativenumber = false
          -- Conditional taken from https://github.com/rockyzhang24/dotfiles/commit/03dd14b5d43f812661b88c4660c03d714132abcf

--- a/plugin/numbertoggle.lua
+++ b/plugin/numbertoggle.lua
@@ -1,14 +1,20 @@
 local augroup = vim.api.nvim_create_augroup("numbertoggle", {})
 
-local function is_disabled()
-   return vim.g.numbertoggle_disable or vim.b.numbertoggle_disable
+local function is_disabled(buf)
+   if vim.g.numbertoggle_disable then
+      return true
+   end
+   if not vim.api.nvim_buf_is_valid(buf) then
+      return nil
+   end
+   return vim.b[buf or 0].numbertoggle_disable
 end
 
 vim.api.nvim_create_autocmd({ "BufEnter", "FocusGained", "InsertLeave", "CmdlineLeave", "WinEnter" }, {
    pattern = "*",
    group = augroup,
-   callback = function()
-      if is_disabled() then
+   callback = function(args)
+      if is_disabled(args.buf) then
          return
       end
       if vim.o.nu and vim.api.nvim_get_mode().mode ~= "i" then
@@ -20,15 +26,15 @@ vim.api.nvim_create_autocmd({ "BufEnter", "FocusGained", "InsertLeave", "Cmdline
 vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter", "CmdlineEnter", "WinLeave" }, {
    pattern = "*",
    group = augroup,
-   callback = function()
-      if is_disabled() then
+   callback = function(args)
+      if is_disabled(args.buf) then
          return
       end
       if vim.o.nu then
          vim.opt.relativenumber = false
          -- Conditional taken from https://github.com/rockyzhang24/dotfiles/commit/03dd14b5d43f812661b88c4660c03d714132abcf
          -- Workaround for https://github.com/neovim/neovim/issues/32068
-         if not vim.tbl_contains({"@", "-"}, vim.v.event.cmdtype) then
+         if not vim.tbl_contains({ "@", "-" }, vim.v.event.cmdtype) then
             vim.cmd "redraw"
          end
       end


### PR DESCRIPTION
Sometimes when screen sharing, I always want to show line number not relative, but the auto-commands clobber that. This lets me dynamically disable them either globally or just for one buffer. This gives the added advantage of being able to have this plugin only be enabled for some file types via an `ftplugin` if desired.

I use `vim.g.numbertoggle_disable` for globally disabling and `vim.b.numbertoggle_disable` for disabling in only a given buffer.

I found these features useful locally so I thought I'd upstream them!